### PR TITLE
Update Async Storage reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "yargs": "6.6.0"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "@react-native-community/async-storage": "*"
   },
   "scripts": {
     "clean": "rimraf dist && mkdirp dist",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import * as utils from './utils';
 
 // get from whatever version of react native that is being used.
-const AsyncStorage = (require('react-native') || {}).AsyncStorage;
+const AsyncStorage = (require('@react-native-community/async-storage') || {}).AsyncStorage;
 
 const storage = {
   setItem(key, value) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import * as utils from './utils';
 
 // get from whatever version of react native that is being used.
-const AsyncStorage = (require('@react-native-community/async-storage') || {}).AsyncStorage;
+const AsyncStorage = require('@react-native-community/async-storage') || {};
 
 const storage = {
   setItem(key, value) {


### PR DESCRIPTION
In order to avoid _"Async Storage has been extracted from react-native core and will be removed in a future release."_, we switched to `@react-native-community/async-storage`. This dependency was the only one that was still using the core's one.